### PR TITLE
SpringSecuirty用のArgumentResolver設定を追加

### DIFF
--- a/src/main/resources/spring/mvc-core-config.xml
+++ b/src/main/resources/spring/mvc-core-config.xml
@@ -33,7 +33,15 @@
     <context:component-scan base-package="jgs.bluemix.sample.web"/>
     <context:component-scan base-package="jgs.bluemix.sample.validation"/>
 
-    <mvc:annotation-driven/>
+    <mvc:annotation-driven>
+        <mvc:argument-resolvers>
+            <!--
+              SpringSecurity用の設定.
+              SpringSecurityに関するController引数を解決するためのHandlerMethodArgumentResolver.
+             -->
+            <bean class="org.springframework.security.web.bind.support.AuthenticationPrincipalArgumentResolver" />
+        </mvc:argument-resolvers>
+    </mvc:annotation-driven>
 
     <mvc:resources mapping="/webjars/**" location="classpath:/META-INF/resources/webjars/"/>
     <mvc:resources mapping="/css/**" location="/css/"/>


### PR DESCRIPTION
SpringSecurityではログイン済ユーザの取得用として`@AuthenticationPrincipal`を提供しており、一部機能（会員情報変更）で当アノテーションを利用している。
当アノテーションはJavaConfigにて`@EnableWebMmvSecurity`を行うことで利用可能となるが、JavaConfigを外す際にこれに相当するXML設定の追加が漏れていた。
会員情報の変更機能を動作させるために`@AuthenticationPrincipal`が利用可能となるようSpringMVC側の設定変更（`HandlerMethodArgumentResolver`の追加)を行う。
